### PR TITLE
Fix example of using generator in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ gem 'ember-cli-rails'
 Then you'll want to configure your installation by adding an `ember.rb` initializer.  There is a generator to guide you, run:
 
 ```shell
-rake ember-cli:init
+rails generate ember-cli:init
 ```
 
 This will generate an initializer that looks like the following:


### PR DESCRIPTION
The README shows using a rake task to generate the initializer. The rake task doesn't exist.

I updated the README to call the generator.
