### PR TITLE
fix helper method's name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ end
 In order to load your EmberCLI generated app you need only include the javscript tags on the page you'd like the Ember app to appear:
 
 ```erb
-<%= ember_cli_script_tags :frontend %>
+<%= include_ember_script_tags :frontend %>
 ```
 
 Your Ember application will be served now.


### PR DESCRIPTION
I think it should be include_ember_script_tags instead of ember_cli_script_tags
https://github.com/rwz/ember-cli-rails/blob/master/lib/ember-cli/view_helpers.rb#L3

a
