### PR TITLE
Server not serving assets as the current rack app does not match the Rails.application

### DIFF
--- a/lib/ember-cli/rack_server.rb
+++ b/lib/ember-cli/rack_server.rb
@@ -1,7 +1,7 @@
 module EmberCLI
   module RackServer
     def start
-      EmberCLI.run! if defined?(Rails.application) && app == Rails.application
+      EmberCLI.run! if defined?(Rails.application)
       super
     ensure
       EmberCLI.stop!


### PR DESCRIPTION
Removed an explicit check to compare a Rack app with Rails.application

I was having issue with using this gem with any application which has a NewRelic RPM gem

As NewRelic gem was overwriting the structure of the current Rack app in such a way that the current Rails was stored under app.target instead of app.

I think we can get away with just checking if we have a Rails.application defined as that give us enough surety that their is a Rails Application. 

``` ruby
=> app
=> #<NewRelic::Agent::Instrumentation::MiddlewareProxy:0x007f8684fd9988
 @category=:rack,
 @is_app=true,
 @target=
  #<Gymy::Application:0x007f8685fceca8
   @_all_autoload_paths=
    ["/Users/rahult/Development/katalyst/rails/koi/gymy/app/assets", ...],
   @_all_load_paths=
    ["/Users/rahult/Development/katalyst/rails/koi/gymy/lib", ...],
   @app=
    #<NewRelic::Agent::Instrumentation::MiddlewareProxy:0x007f8685fa4368
```

instead of 

``` ruby
=> app
=> #<Gymy::Application:0x007f8685fceca8
   @_all_autoload_paths=
    ["/Users/rahult/Development/katalyst/rails/koi/gymy/app/assets", ...],
   @_all_load_paths=
    ["/Users/rahult/Development/katalyst/rails/koi/gymy/lib", ...],
   @app=
    #<NewRelic::Agent::Instrumentation::MiddlewareProxy:0x007f8685fa4368
```
