### PR TITLE
Don't throw an error if the symlink already exists

### DIFF
--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -43,7 +43,10 @@ module EmberCLI
     end
 
     def symlink_to_assets_root
-      assets_path.join(name).make_symlink dist_path.join("assets")
+      begin
+        assets_path.join(name).make_symlink dist_path.join("assets")
+      rescue Errno::EEXIST => e
+      end
     end
 
     def add_assets_to_precompile_list


### PR DESCRIPTION
I'm running Unicorn in development with two worker processes, which is causing the symlink creation to be attempted twice.
