### PR TITLE
Bump dependency on ember-cli-rails to 0.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Once you've updated your initializer to taste, you need to install the
 For each of your EmberCLI applications install the addon with:
 
 ```sh
-npm install --save-dev ember-cli-rails-addon@0.0.3
+npm install --save-dev ember-cli-rails-addon@0.0.5
 ```
 
 And that's it!

--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -2,7 +2,7 @@ require "timeout"
 
 module EmberCLI
   class App
-    ADDON_VERSION = "0.0.3"
+    ADDON_VERSION = "0.0.5"
     EMBER_CLI_VERSION = "~> 0.1.3"
 
     attr_reader :name, :options, :pid


### PR DESCRIPTION
This version of the addon includes a monkeypatch that properly fires the
`preBuild` hook before build is invoked.

fixes #31
