### PR TITLE
Handle Legacy Rails' lack of acronym support

### DIFF
--- a/app/helpers/ember_rails_helper.rb
+++ b/app/helpers/ember_rails_helper.rb
@@ -1,4 +1,4 @@
-module EmberCLIRailsHelper
+module EmberRailsHelper
   def include_ember_script_tags(name, options={})
     javascript_include_tag *EmberCLI[name].exposed_js_assets, options
   end


### PR DESCRIPTION
Handles `load_missing_constant` failures

```
/Users/Sean/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/activesupport-3.1.12/lib/active_support/dependencies.rb:490:in `load_missing_constant': Expected /Users/Sean/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/ember-cli-rails-0.2.2/app/helpers/ember_cli_rails_helper.rb to define EmberCliRailsHelper (LoadError)
        from /Users/Sean/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/activesupport-3.1.12/lib/active_support/dependencies.rb:181:in `block in const_missing'
        from /Users/Sean/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/activesupport-3.1.12/lib/active_support/dependencies.rb:179:in `each'
        from /Users/Sean/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/activesupport-3.1.12/lib/active_support/dependencies.rb:179:in `const_missing'
```
