### PR TITLE
Register with Sprockets on Rails initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 master
 ------
 
+* Register EmberCLI app with Sprockets on application initialization
 * Rename `ember-cli` to `ember_cli` in Ruby.
 
 0.5.1

--- a/lib/ember_cli/app.rb
+++ b/lib/ember_cli/app.rb
@@ -84,7 +84,6 @@ module EmberCli
       @prepared ||= begin
         @build.reset
         symlink_to_assets_root
-        sprockets.register!
         true
       end
     end

--- a/lib/ember_cli/configuration.rb
+++ b/lib/ember_cli/configuration.rb
@@ -13,7 +13,9 @@ module EmberCli
         deprecate_enable
       end
 
-      apps.store name, App.new(name, options)
+      app = App.new(name, options)
+      app.sprockets.register!
+      apps.store(name, app)
     end
 
     def apps


### PR DESCRIPTION
This commit prevents an EmberCLI application from registering with
Sprockets multiple times, which would clutter the precompile list.
