### PR TITLE
Document asset helpers serving from the development server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ main
   `development`, so that changes are hot-reloaded instead of requiring a
   restart. Configure it with the `dev_server` option, or opt out with
   `dev_server: false`
+* Require `ember-cli-rails-assets >= 0.9.0`, which serves the
+  `include_ember_script_tags` startup tags from Vite's development server
+  when the application is served from it
 
 0.13.0.beta1
 ------

--- a/README.md
+++ b/README.md
@@ -527,14 +527,12 @@ When the application is served by [Vite's development
 server](#vite-based-applications), `include_ember_script_tags` (from
 [ember-cli-rails-assets]) reads `index.html` from the server and emits the
 startup tags with absolute URLs pointing at it — nothing is built, and changes
-to the application are picked up by reloading the page. This needs the
-ember-cli-rails-assets release carrying
-[tricknotes/ember-cli-rails-assets#35][assets-dev-server]; with older
-releases, disable the development server with `dev_server: false` so that the
-assets the helpers refer to are built (the build is then rerun on the next
-request after the application's source files change).
+to the application are picked up by reloading the page.
 
-[assets-dev-server]: https://github.com/tricknotes/ember-cli-rails-assets/pull/35
+With the development server disabled (`dev_server: false`), the helpers read
+the output of `ember build` instead: the application is built once,
+synchronously, on the first request, and changes to it are only picked up by
+restarting the Rails server.
 
 Following the example above, configure the mounted EmberCLI application to be
 served by a custom controller (`ApplicationController`, in this case).
@@ -760,10 +758,9 @@ Note the following limitations for Vite-based applications:
   classic-only and must not be called for Vite-based applications
 * in development, the application is served by [Vite's development
   server](#vite-based-applications) rather than out of a build directory. The
-  asset helpers serve their tags from the development server too (with the
-  ember-cli-rails-assets release carrying [tricknotes/ember-cli-rails-assets#35][assets-dev-server]);
-  with older releases they require the development server to be disabled with
-  `dev_server: false`
+  asset helpers serve their tags from the development server too; with
+  `dev_server: false` they read the build output, which is built once,
+  synchronously, on the first request
 
 ## Ruby and Rails support
 

--- a/README.md
+++ b/README.md
@@ -523,11 +523,18 @@ and `modulepreload` links, and the ES module script tags — extracted from
 the generated `index.html`. `include_ember_stylesheet_tags` only supports
 classic (Broccoli-based) applications.
 
-The asset helpers always read the output of `ember build`, so they do not use
-[Vite's development server](#vite-based-applications). To serve a Vite-based
-application from it, render the application with `render_ember_app`. Otherwise,
-disable the development server with `dev_server: false` so that the assets the
-helpers refer to are built.
+When the application is served by [Vite's development
+server](#vite-based-applications), `include_ember_script_tags` (from
+[ember-cli-rails-assets]) reads `index.html` from the server and emits the
+startup tags with absolute URLs pointing at it — nothing is built, and changes
+to the application are picked up by reloading the page. This needs the
+ember-cli-rails-assets release carrying
+[tricknotes/ember-cli-rails-assets#35][assets-dev-server]; with older
+releases, disable the development server with `dev_server: false` so that the
+assets the helpers refer to are built (the build is then rerun on the next
+request after the application's source files change).
+
+[assets-dev-server]: https://github.com/tricknotes/ember-cli-rails-assets/pull/35
 
 Following the example above, configure the mounted EmberCLI application to be
 served by a custom controller (`ApplicationController`, in this case).
@@ -753,8 +760,10 @@ Note the following limitations for Vite-based applications:
   classic-only and must not be called for Vite-based applications
 * in development, the application is served by [Vite's development
   server](#vite-based-applications) rather than out of a build directory. The
-  asset helpers read that build directory, so they require the development
-  server to be disabled with `dev_server: false`
+  asset helpers serve their tags from the development server too (with the
+  ember-cli-rails-assets release carrying [tricknotes/ember-cli-rails-assets#35][assets-dev-server]);
+  with older releases they require the development server to be disabled with
+  `dev_server: false`
 
 ## Ruby and Rails support
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -16,7 +16,7 @@ following differences in how `ember-cli-rails` treats it:
   `include_ember_stylesheet_tags`: for Vite-based applications it emits the
   configuration meta tag, the stylesheet links, and the module script tags
   all together, while `include_ember_stylesheet_tags` supports only classic
-  applications. This requires `ember-cli-rails-assets >= 0.8.0`.
+  applications. This requires `ember-cli-rails-assets >= 0.9.0`.
 * In development, the application is served by Vite's development server —
   the same one the application's `npm start` script runs. `ember-cli-rails`
   starts it on the first request and shuts it down when Rails exits, and
@@ -36,10 +36,11 @@ following differences in how `ember-cli-rails` treats it:
   end
   ```
 
-* `include_ember_script_tags` reads the output of `ember build`, which the
-  development server does not produce. Render Vite-based applications with
-  `render_ember_app`, or disable the development server with
-  `dev_server: false` to keep using the asset helpers.
+* `include_ember_script_tags` serves its startup tags from the development
+  server, with absolute URLs pointing at it — nothing is built, and changes
+  are picked up by reloading the page. With `dev_server: false` it reads the
+  output of `ember build` instead, built once, synchronously, on the first
+  request; restart the Rails server to pick up changes.
 
 [Vite]: https://vitejs.dev
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -24,13 +24,22 @@ following differences in how `ember-cli-rails` treats it:
   the application's modules, and Vite's HMR client, from it directly. Changes
   are hot-reloaded without restarting Rails.
 
-  Configure it, or opt out of it, with the `dev_server` option:
+  The development server is the default — and the recommended — way to
+  develop a Vite-based application, and needs no configuration. When
+  configuring it anyway, a fixed `port` lets several Rails workers (or a
+  hand-started `npm start`) share a single server, and a longer `timeout`
+  accommodates a slow first boot:
 
   ```rb
   EmberCli.configure do |c|
-    # listen on a fixed port instead of an available one
-    c.app :frontend, dev_server: { port: 4200 }
+    c.app :frontend, dev_server: { port: 4200, timeout: 120 }
+  end
+  ```
 
+  To opt out of the development server, disable it:
+
+  ```rb
+  EmberCli.configure do |c|
     # build once, synchronously, on the first request instead
     c.app :admin, dev_server: false
   end

--- a/ember-cli-rails.gemspec
+++ b/ember-cli-rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.5.0"
 
-  spec.add_dependency "ember-cli-rails-assets", ">= 0.8.0", "< 1.0"
+  spec.add_dependency "ember-cli-rails-assets", ">= 0.9.0", "< 1.0"
   spec.add_dependency "railties", ">= 4.2"
   spec.add_dependency "rack", ">= 2.1", "< 4.0"
   spec.add_dependency "terrapin", "~> 0.6.0"


### PR DESCRIPTION
## Summary

Companion to tricknotes/ember-cli-rails-assets#35, released as ember-cli-rails-assets 0.9.0: `include_ember_script_tags` reads `index.html` from Vite's development server and emits the startup tags with absolute URLs pointing at it, so embedding a Vite-based application into Rails-owned HTML no longer requires `dev_server: false`, and changes are picked up by reloading the page instead of waiting for a full build.

The API the helper needs (`App#dev_server?`, and `App#dev_server` with `index_html` and `origin`) is already public on the #653 branch, so this side is documentation and dependency housekeeping:

- Raise the gemspec's ember-cli-rails-assets constraint to `>= 0.9.0`, the release that carries the development-server support (verified to resolve)
- Update the README and UPGRADING passages that hedged about older ember-cli-rails-assets releases: the helpers' development-server behavior is now stated plainly, and `dev_server: false` is described as the opt-out it is (the helpers then read the build output, built once on the first request)
- State in the upgrading guide that the development server is the default and recommended setup for Vite-based applications, with a reference configuration (a fixed `port` so that several Rails workers share one server, and a longer `timeout` for a slow first boot)
- Fold the requirement change into the CHANGELOG entry

Stacked directly on #653 (the interim `vite-recompile-on-change` base was dropped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)