### PR TITLE
Re-enable the Rails main CI job with rspec-rails main

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,11 +9,16 @@ on:
 
 jobs:
   build:
+    # Named explicitly so that `experimental` stays out of the job name.
+    name: "build (${{ matrix.ruby }}, ${{ matrix.rails }}, ${{ matrix.ember }})"
     runs-on: "ubuntu-latest"
 
     # Jobs normally finish in about 3 minutes; a hung job once ran for
     # 2 hours until it was cancelled by hand, so cap the runtime.
     timeout-minutes: 15
+
+    # Rails main is a moving target, so let it break without failing the build.
+    continue-on-error: ${{ matrix.experimental || false }}
 
     strategy:
       fail-fast: false
@@ -25,14 +30,10 @@ jobs:
         # versions use the classic Broccoli-based build.
         ember: ["7.0.0"]
         include:
-          # Disabled: rspec-rails 6.x (the newest the gemspec allows)
-          # fails to load specs against rails/rails main with
-          # `FrozenError: can't modify frozen Hash`. Re-enable once the
-          # rspec-rails dependency can be upgraded to a series that
-          # supports Rails main.
-          # - ruby: "4.0"
-          #   rails: "main"
-          #   ember: "7.0.0"
+          - ruby: "4.0"
+            rails: "main"
+            ember: "7.0.0"
+            experimental: true
           # Classic (Broccoli-based) blueprint coverage
           - ruby: "3.4"
             rails: "8.1"

--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,11 @@ gem "rails", rails_constraint
 gem "high_voltage", "~> 3.0.0"
 gem "selenium-webdriver", ">= 4.11"
 gem "webrick"
+
+if rails_version == "main"
+  # The released rspec-rails series mutates internals that Rails main
+  # freezes, failing the suite while loading the specs. Until a release
+  # carries the fixes (e.g. https://github.com/rspec/rspec-rails/pull/2915),
+  # test against rspec-rails main.
+  gem "rspec-rails", github: "rspec/rspec-rails", branch: "main"
+end

--- a/ember-cli-rails.gemspec
+++ b/ember-cli-rails.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "html_page", "~> 0.1.0"
 
   spec.add_development_dependency "generator_spec", "~> 0.9.0"
-  spec.add_development_dependency "rspec-rails", ">= 3.6.0", "< 7.0"
+  spec.add_development_dependency "rspec-rails", ">= 3.6.0", "< 9.0"
 
   spec.add_development_dependency "capybara-selenium"
   spec.add_development_dependency "codeclimate-test-reporter", "~> 0.6.0"


### PR DESCRIPTION
## Summary

The Rails main CI job was disabled because the released rspec-rails series mutates internals that Rails main freezes, failing the suite while loading the specs (`FrozenError: can't modify frozen Hash`). The fixes (e.g. rspec/rspec-rails#2915) are merged on rspec-rails main but not yet released.

- Widen the gemspec's rspec-rails development-dependency constraint from `< 7.0` to `< 9.0`, admitting the 8.x series. The constraint also applies to the git source, whose current prerelease is 8.1.0.pre, so this is what lets the main branch resolve.
- When `RAILS_VERSION=main`, take rspec-rails from its main branch in the Gemfile, following the existing switch for the rails constraint.
- Re-enable the `(4.0, main, 7.0.0)` matrix entry, marked `experimental` with `continue-on-error` so the moving target can break without failing the build (the same arrangement as tricknotes/ember-cli-rails-assets#36 relies on).

## Notes

- With the widened constraint, released Rails versions now resolve rspec-rails to the released 8.x series (8.0.4 at the moment) instead of 6.1.5, so the whole matrix moves to rspec-rails 8 (which requires Rails >= 7.2 — the matrix's minimum).

## Verification

- `RAILS_VERSION=main bundle lock` resolves, picking up rspec-rails 8.1.0.pre from main against rails main
- `bundle lock` with the default `RAILS_VERSION` resolves to rspec-rails 8.0.4
- `spec/lib` passes locally against rspec-rails 8.0.4 (79 of 81 examples; the 2 failures are a local environment issue — no `ember-cli` executable installed — not related to rspec-rails)
- Please rely on CI for the full matrix, and on the experimental `build (4.0, main, 7.0.0)` job for the Rails main run

🤖 Generated with [Claude Code](https://claude.com/claude-code)