### PR TITLE
Cap the CI job runtime at 15 minutes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,10 @@ jobs:
   build:
     runs-on: "ubuntu-latest"
 
+    # Jobs normally finish in about 3 minutes; a hung job once ran for
+    # 2 hours until it was cancelled by hand, so cap the runtime.
+    timeout-minutes: 15
+
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Add `timeout-minutes: 15` to the CI build job. Jobs normally finish in about 3 minutes, so 15 minutes leaves plenty of headroom — but without a cap, a hung job runs until GitHub's 6-hour default: [one run](https://github.com/tricknotes/ember-cli-rails/actions/runs/33611883082) recently sat for 2 hours until it was cancelled by hand.

## Notes

- #655 touches the adjacent lines of the same job definition, so whichever merges second may need a trivial conflict resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)