### PR TITLE
Run CI for pull requests against any base branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches: "*"
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

The `pull_request` trigger filtered base branches with `branches: "*"`, but [the `*` glob does not match `/`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet), so a pull request whose base branch name contains a slash silently gets no CI runs at all. This is why #654 stopped getting runs the moment its base was retargeted to `claude/vite-dev-server-hmr-y3xm8i`, while pull requests based on `main` kept running.

Drop the filter: an unfiltered `pull_request` trigger already means every base branch, which is what `"*"` was evidently meant to express.

## Notes

- For #654 to pick this up, the fix also needs to reach its base branch (the workflow definition for `pull_request` events is read from the merge ref), e.g. by merging main into the #653 branch after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)