### PR TITLE
Release 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-main
+0.13.0
 ------
 
 * Serve Vite-based applications from Vite's development server in

--- a/lib/ember_cli/version.rb
+++ b/lib/ember_cli/version.rb
@@ -1,3 +1,3 @@
 module EmberCli
-  VERSION = "0.13.0.beta1".freeze
+  VERSION = "0.13.0".freeze
 end


### PR DESCRIPTION
## Summary

Release 0.13.0, carrying the development-server work now on main:

* Serve Vite-based applications from Vite's development server in `development` (#653)
* Require `ember-cli-rails-assets >= 0.9.0`, which serves the `include_ember_script_tags` startup tags from the development server (#654)
* Add an `origin` option to `dev_server`, separating the browser-facing origin from the bind address (#658)

Bumps `EmberCli::VERSION` from `0.13.0.beta1` to `0.13.0` and retitles the unreleased CHANGELOG section accordingly. The `0.13.0.beta1` section stays as its own released entry — that version is already on rubygems (2026-08-22) and predates the development-server work, which is why this release needs a new version number.