### PR TITLE
Report a failing Ember suite instead of exiting the process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+main
+------
+
+* Fix `EmberCli::App#test` to report a failing suite by returning `false`
+  instead of exiting the process from inside the gem — one failing Ember suite
+  no longer aborts the caller (RSpec included) mid-run. `EmberCli.test!`
+  raises `EmberCli::TestFailureError` when a suite fails, which still exits
+  `rake ember:test` nonzero
+
 0.13.0
 ------
 

--- a/lib/ember_cli.rb
+++ b/lib/ember_cli.rb
@@ -44,7 +44,11 @@ module EmberCli
   end
 
   def test!
-    each_app(&:test)
+    each_app do |app|
+      unless app.test
+        fail TestFailureError, "The Ember test suite failed for #{app.name.inspect}"
+      end
+    end
   end
 
   def compile!

--- a/lib/ember_cli/errors.rb
+++ b/lib/ember_cli/errors.rb
@@ -1,4 +1,5 @@
 module EmberCli
   class BuildError < StandardError; end
   class DependencyError < BuildError; end
+  class TestFailureError < StandardError; end
 end

--- a/lib/ember_cli/shell.rb
+++ b/lib/ember_cli/shell.rb
@@ -81,7 +81,7 @@ module EmberCli
     end
 
     def test
-      run! ember.test
+      run ember.test
     end
 
     private

--- a/spec/lib/ember_cli/shell_spec.rb
+++ b/spec/lib/ember_cli/shell_spec.rb
@@ -1,0 +1,35 @@
+require "ember_cli/shell"
+
+describe EmberCli::Shell do
+  describe "#test" do
+    it "returns a successful status when the suite passes" do
+      shell = build_shell(ember: "true")
+
+      status = shell.test
+
+      expect(status).to be_success
+    end
+
+    it "returns an unsuccessful status when the suite fails" do
+      shell = build_shell(ember: "false")
+
+      status = shell.test
+
+      expect(status).not_to be_success
+    end
+  end
+
+  # The `ember` executable is the seam: `Command#test` builds the command
+  # line from it, so `true` and `false` stand in for a passing and a failing
+  # `ember test` run.
+  def build_shell(ember:)
+    paths = double(
+      "EmberCli::PathSet",
+      ember: ember,
+      root: Pathname.new(Dir.pwd),
+      log: Pathname.new(File::NULL),
+    )
+
+    EmberCli::Shell.new(paths: paths)
+  end
+end

--- a/spec/lib/ember_cli_spec.rb
+++ b/spec/lib/ember_cli_spec.rb
@@ -12,6 +12,33 @@ describe EmberCli do
     end
   end
 
+  describe ".test!" do
+    it "runs every application's test suite" do
+      passing = test_app(name: "passing", passed: true)
+      also_passing = test_app(name: "also-passing", passed: true)
+      stub_apps(passing: passing, also_passing: also_passing)
+
+      EmberCli.test!
+
+      expect(passing).to have_received(:test)
+      expect(also_passing).to have_received(:test)
+    end
+
+    it "raises when an application's test suite fails" do
+      failing = test_app(name: "failing", passed: false)
+      stub_apps(failing: failing)
+
+      expect { EmberCli.test! }.to raise_error(
+        EmberCli::TestFailureError,
+        /"failing"/,
+      )
+    end
+
+    def test_app(name:, passed:)
+      instance_double(EmberCli::App, name: name, test: passed)
+    end
+  end
+
   def stub_apps(applications)
     allow(EmberCli).to receive(:apps).and_return(applications)
   end


### PR DESCRIPTION
## Summary

`Shell#test` ran `ember test` through `Runner#run!`, which calls `exit` when the command fails. `App#test` therefore could never return the `false` its `success?` call promises: any consumer running the suite from Ruby was terminated mid-run.

The gem's own RSpec suite is such a consumer — when the `EmberCli::App#test` example's `ember test` run fails (e.g. no Chrome available), the whole RSpec process exits at that point, reporting however many examples had run so far with `0 failures`. Observed as example counts varying between 2 and 103 across runs of the same revision.

Changes:

* `Shell#test` runs the suite with `Runner#run` and returns the status, so `App#test` reports the outcome to its caller
* `EmberCli.test!` raises `EmberCli::TestFailureError` (naming the failing application) when a suite fails, so library consumers can rescue the failure in Ruby instead of having their process terminated; the exception still exits `rake ember:test` nonzero
* `Runner#run!` keeps its exiting behavior for `compile` and `install`, whose rake tasks rely on it (its spec documents the `SystemExit`)
* Add specs for `Shell#test` (both outcomes) and `EmberCli.test!` (runs every suite; raises on failure), and a CHANGELOG entry

## Verification

* `spec/lib` now runs to completion deterministically: the same example count on every run (previously the count varied per seed), with the one genuine failure on this machine being the Chrome-dependent `App#test` example — reported as a failure instead of aborting the suite
* On CI, where Chrome is available, that example passes as before