### PR TITLE
Resolve Rails 8.1 deprecation warnings in the dummy application

### DIFF
--- a/spec/dummy/application.rb
+++ b/spec/dummy/application.rb
@@ -33,7 +33,9 @@ module Dummy
     config.secret_token = "SECRET_TOKEN_IS_MIN_30_CHARS_LONG"
     config.secret_key_base = "SECRET_KEY_BASE"
 
-    config.active_support.to_time_preserves_timezone = :zone
+    if Rails.gem_version < Gem::Version.new("8.1")
+      config.active_support.to_time_preserves_timezone = :zone
+    end
 
     def require_environment!
       initialize!

--- a/spec/dummy/config/initializers/high_voltage.rb
+++ b/spec/dummy/config/initializers/high_voltage.rb
@@ -2,4 +2,5 @@ require "high_voltage"
 
 HighVoltage.configure do |config|
   config.layout = false
+  config.routes = false
 end


### PR DESCRIPTION
## Summary

The Rails 8.1 CI jobs emit two kinds of deprecation warnings (e.g. [this job](https://github.com/tricknotes/ember-cli-rails/actions/runs/33852995084/job/100959806287)):

* `config.active_support.to_time_preserves_timezone` is deprecated and will be removed in Rails 8.2 — preserving the timezone is the only behavior on 8.1, so the dummy application now assigns the setting only on older Rails versions.
* `get received a hash argument as` / `get received a hash argument /pages/*id` — this comes from HighVoltage's `/pages/*id` engine route, which is still defined with the deprecated hash-argument style (its latest release, 5.0.0, included). The gem's own `mount_ember_app` passes keywords and is not affected. The dummy application only uses HighVoltage's controller and templates, not the engine route, so it stops drawing it via `HighVoltage.configure { |config| config.routes = false }`.

## Verification

* Reproduced all three warnings under Rails 8.1 by initializing the dummy application and drawing its routes; after the change the same procedure emits none.
* Repeated the procedure under Rails 7.2 (the Gemfile default) to confirm nothing regresses; `spec/lib` passes under 8.1.