### PR TITLE
Release 0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-main
+0.13.1
 ------
 
 * Fix `EmberCli::App#test` to report a failing suite by returning `false`

--- a/lib/ember_cli/version.rb
+++ b/lib/ember_cli/version.rb
@@ -1,3 +1,3 @@
 module EmberCli
-  VERSION = "0.13.0".freeze
+  VERSION = "0.13.1".freeze
 end


### PR DESCRIPTION
## Summary

Release 0.13.1, carrying the fix merged since 0.13.0:

* A failing Ember suite is reported instead of exiting the process from inside the gem: `App#test` returns `false`, and `EmberCli.test!` raises `EmberCli::TestFailureError` — which still exits `rake ember:test` nonzero (#660)

#661 (Rails 8.1 deprecation cleanup) only touches the dummy application, so it ships no user-facing change and has no CHANGELOG entry.

Bumps `EmberCli::VERSION` from `0.13.0` to `0.13.1` and retitles the unreleased CHANGELOG section accordingly.