### PR TITLE
Raise BuildError when a build or install command fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+main
+------
+
+* Raise `EmberCli::BuildError` when `ember build` or a dependency
+  installation fails, instead of exiting the process from inside the gem —
+  `rake ember:compile` and `rake ember:install` still exit nonzero
+
 0.13.1
 ------
 

--- a/lib/ember_cli/runner.rb
+++ b/lib/ember_cli/runner.rb
@@ -1,5 +1,7 @@
 require "open3"
 
+require "ember_cli/errors"
+
 module EmberCli
   class Runner
     def initialize(out:, err:, env: {}, options: {})
@@ -25,7 +27,7 @@ module EmberCli
     def run!(command)
       run(command).tap do |status|
         unless status.success?
-          exit status.exitstatus
+          fail BuildError, "`#{command}` failed with status #{status.exitstatus}"
         end
       end
     end

--- a/spec/lib/ember_cli/runner_spec.rb
+++ b/spec/lib/ember_cli/runner_spec.rb
@@ -12,7 +12,7 @@ describe EmberCli::Runner do
         )
 
         expect { runner.run!(command_with_error(out: "out")) }.
-          to raise_error(SystemExit)
+          to raise_error(EmberCli::BuildError, /failed with status 1/)
 
         expect(split_output_from_stream(stdout)).to eq(%w[out out])
         expect(split_output_from_stream(logfile)).to eq(%w[out out])
@@ -27,7 +27,7 @@ describe EmberCli::Runner do
         )
 
         expect { runner.run!(command_with_error(err: "err")) }.
-          to raise_error(SystemExit)
+          to raise_error(EmberCli::BuildError, /failed with status 1/)
 
         expect(split_output_from_stream(stderr)).to eq(%w[err err])
         expect(split_output_from_stream(logfile)).to eq(%w[err err])


### PR DESCRIPTION
## Summary

`Runner#run!` exited the calling process when its command failed, so a failing `ember build` or dependency installation terminated any Ruby process running it — callers of `EmberCli.compile!` and `EmberCli.install_dependencies!` included. `App#compile` also runs during request handling in development, where a build failure could take the Rails server down with it.

* `Runner#run!` now raises `EmberCli::BuildError`, naming the command and its exit status, instead of calling `exit`
* The rake tasks (`ember:compile` / `ember:install`) still exit nonzero, now through the uncaught exception
* A request-time build failure surfaces the same way `BuildMonitor#check!` failures already do (both raise `BuildError`)
* Update the `Runner#run!` spec (which documented the `SystemExit`) and add a CHANGELOG entry

This completes the exit removal started for `ember test` in #660, which raises `EmberCli::TestFailureError` since 0.13.1.

## Verification

* `spec/lib`: 126 examples, with the only local failure being the known Chrome-dependent `App#test` example (passes on CI); the `App#compile` example exercises a real `ember build` through the new path