### PR TITLE
Release 0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-main
+0.13.2
 ------
 
 * Raise `EmberCli::BuildError` when `ember build` or a dependency

--- a/lib/ember_cli/version.rb
+++ b/lib/ember_cli/version.rb
@@ -1,3 +1,3 @@
 module EmberCli
-  VERSION = "0.13.1".freeze
+  VERSION = "0.13.2".freeze
 end


### PR DESCRIPTION
## Summary

Release 0.13.2, carrying the changes merged since 0.13.1:

* Raise `EmberCli::BuildError` when `ember build` or a dependency installation fails, instead of exiting the process from inside the gem — `rake ember:compile` and `rake ember:install` still exit nonzero (#663)
* Remap the root-relative asset URLs in a Vite build's `index.html` onto the mount point when `mount_ember_app` serves the application from a path other than `/`, so non-root mounts work without a matching `rootURL` (#666)

Bumps `EmberCli::VERSION` from `0.13.1` to `0.13.2` and retitles the unreleased CHANGELOG section accordingly. Rebased onto main after #666 merged, so the release section carries both entries.