### PR TITLE
Assert render_ember_app pages emit a single HTML document

### DIFF
--- a/spec/features/user_views_ember_app_spec.rb
+++ b/spec/features/user_views_ember_app_spec.rb
@@ -35,6 +35,20 @@ feature "User views ember app", :js do
     end
   end
 
+  # `render_ember_app` emits the application's complete HTML document, so the
+  # rendering action must disable its layout — the dummy application uses
+  # `HighVoltage.layout = false` — or the document ends up nested inside the
+  # layout's `<body>`.
+  scenario "renders a single, complete HTML document", js: false do
+    [include_index_path, include_index_head_and_body_path, default_path].each do |path|
+      visit path
+
+      expect(page.html.scan(/<!DOCTYPE/i).count).to eq(1)
+      expect(page.html.scan(/<html/i).count).to eq(1)
+      expect(page.html).not_to include("<title>Dummy</title>")
+    end
+  end
+
   scenario "is redirected with trailing slash", js: false do
     expect(include_index_path).to eq("/no-block")
 


### PR DESCRIPTION
## Summary

`render_ember_app` emits the application's complete HTML document, so the rendering action must disable its layout — otherwise the document ends up nested inside the layout's `<body>`. The README documents this (`render layout: false`), and the dummy application already complies: its `render_ember_app` pages go through HighVoltage with `HighVoltage.layout = false`, and `EmberCli::EmberController#index` renders with `layout: false`.

Nothing asserted that, though: a layout misconfiguration in the dummy would produce invalid, nested documents while every example still passed. Add a scenario asserting that the pages rendered through `render_ember_app` (custom-controller pages and the default mount) contain exactly one doctype and one `<html>` element, and none of the layout's markup.

## Verification

* Confirmed empirically that the current dummy emits single, non-nested documents on `/no-block/`, `/head-and-body-block/`, and `/` (one `<!DOCTYPE>`, one `<html>`, no layout `<title>`), then locked that in with the new scenario
* The scenario runs under the rack_test driver (`js: false`) and passes locally