### PR TITLE
Keep a crashed browser from eating the CI job

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,8 +1,12 @@
+require "timeout"
+
 require "selenium/webdriver"
 
 Capybara.register_driver :headless_chrome do |app|
+  # `--disable-dev-shm-usage` keeps Chrome off the small `/dev/shm` of CI
+  # runners and containers, where exhausting it crashes the renderer.
   options = Selenium::WebDriver::Chrome::Options.new(
-    args: %w[--no-sandbox --headless],
+    args: %w[--no-sandbox --headless --disable-dev-shm-usage],
   )
 
   # Point Selenium at a specific Chrome binary, e.g. inside a container
@@ -23,3 +27,11 @@ end
 
 Capybara.server = :webrick
 Capybara.javascript_driver = :headless_chrome
+
+RSpec.configure do |config|
+  # A crashed browser can leave the driver waiting forever: fail the example
+  # with a backtrace instead of eating the job's runtime cap.
+  config.around(:each, :js) do |example|
+    Timeout.timeout(300) { example.run }
+  end
+end


### PR DESCRIPTION
## Summary

CI jobs intermittently go silent right after an `ember build` finishes, until `timeout-minutes: 15` cancels them (e.g. [this job](https://github.com/tricknotes/ember-cli-rails/actions/runs/33871839705/job/101019404482); the same signature cancelled a job this morning). The orphan-process list at cleanup shows `chromedriver`, `chrome`, and two `chrome_crashpad_handler` processes: the renderer crashes mid-example and the driver waits on it forever, so the job produces no output and no failure.

* Run headless Chrome with `--disable-dev-shm-usage`. Chrome's shared memory lives in `/dev/shm`, which is small on CI runners and containers; exhausting it crashes the renderer — the crashpad handlers are its trace. This is the standard mitigation for headless Chrome in CI.
* As a second line of defense, cap `:js` examples at five minutes (the `Timeout.timeout(300)` arrangement the `App#test` example already uses). A hung browser then fails one example with a backtrace — and the existing failure hook dumps the page and browser console — and the rest of the suite still runs, instead of the job being cancelled with no diagnostics.

## Verification

* The `js: false` feature scenarios pass locally with the reconfigured support file loaded (the `:js` examples need Chrome, which CI provides)
* The hang is intermittent, so the flags can't be proven locally — the crash signature (crashpad handlers among the orphans) and the `/dev/shm` mechanism match, and the timeout layer bounds any residual hang