### PR TITLE
Describe deployment for the blueprint the gem now supports

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,9 +364,7 @@ To configure your EmberCLI-Rails applications for Heroku:
 
 1. Execute `rails generate ember:heroku`.
 1. Commit the newly generated files.
-1. [Add the NodeJS buildpack][buildpack] and configure NPM to include the
-   `bower` dependency's executable file (if your build process requires
-   `bower`).
+1. [Add the NodeJS buildpack][buildpack].
 
 ```sh
 $ heroku buildpacks:clear
@@ -381,10 +379,21 @@ You are ready to deploy:
 $ git push heroku master
 ```
 
-EmberCLI compilation happens at deploy-time, triggered by the `asset:precompile` rake task.
+EmberCLI compilation happens at deploy-time, triggered by the
+`assets:precompile` rake task. This is the same for both build systems: Vite's
+[development server](#vite-based-applications) only runs in `development`, so
+a Vite-based application deploys exactly like a classic one — `ember build`
+writes to the build directory, and Rails serves the result.
 
 **NOTE** Run the generator each time you introduce additional EmberCLI
 applications into the project.
+
+**NodeJS version** — the buildpack reads `engines.node` from the *project
+root's* `package.json` (the file the generator writes), not from the Ember
+application's, and builds on the current LTS release when it names no version.
+Make sure the generated file requires a NodeJS that satisfies your Ember
+application's own `engines.node`: applications generated with `ember-cli >=
+6.8` require NodeJS `>= 20.19.0`.
 
 [buildpack]: https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app#adding-a-buildpack
 
@@ -400,12 +409,14 @@ A build-pack solution for this is discussed in [Issue #491][#491].
 
 ### Capistrano
 
-EmberCLI-Rails executes both `npm install` and `bower install` during EmberCLI's
-compilation, triggered by the  `asset:precompile` rake task.
+EmberCLI-Rails installs the Ember application's NodeJS dependencies during
+EmberCLI's compilation, triggered by the `assets:precompile` rake task. It runs
+`npm install`, or `yarn install` for an application configured with the `yarn`
+option.
 
-The `npm` and `bower` executables are required to be defined in the deployment
-SSH session's `$PATH`. It is not sufficient to modify the session's `$PATH` in
-a `.bash_profile`.
+The executables it runs are required to be defined in the deployment SSH
+session's `$PATH`. It is not sufficient to modify the session's `$PATH` in a
+`.bash_profile`.
 
 To resolve this issue, prepend the Node installation's `bin` directory to the
 target system's `$PATH`:
@@ -414,26 +425,26 @@ target system's `$PATH`:
 #config/deploy/production.rb
 
 set :default_env, {
-  "PATH" => "/home/deploy/.nvm/versions/node/v4.2.1/bin:$PATH"
+  "PATH" => "/home/deploy/.nvm/versions/node/v22.11.0/bin:$PATH"
 }
 ```
 
 The system in this example is using `nvm` to configure the node version. If
 you're not using `nvm`, make sure the string you prepend to the `$PATH` variable
-contains the directory or directories that contain the `bower` and `npm`
-executables.
+contains the directory or directories that contain the executables above. Point
+it at a NodeJS that satisfies the Ember application's `engines.node`:
+applications generated with `ember-cli >= 6.8` require NodeJS `>= 20.19.0`.
 
 #### For faster deployments
 
 Place the following in your `deploy/<environment>.rb`
 
 ```ruby
-set :linked_dirs, %w{<ember-app-name>/node_modules <ember-app-name>/bower_components}
+set :linked_dirs, %w{<ember-app-name>/node_modules}
 ```
 
-to avoid rebuilding all the node modules and bower components with every deploy.
-Replace `<ember-app-name>` with the name of your ember app (default is
-`frontend`).
+to avoid rebuilding all the node modules with every deploy. Replace
+`<ember-app-name>` with the name of your ember app (default is `frontend`).
 
 ## Override
 


### PR DESCRIPTION
Documentation-only. Brings the Heroku and Capistrano instructions in line with the build system the gem now centers on.

## Why

The deployment instructions were written when every EmberCLI application was a classic Broccoli build that installed Bower dependencies. An application generated with `ember-cli >= 6.8` has no `bower.json`, so a reader following the README today is told to configure a Bower executable that nothing runs and to link a `bower_components` directory that is never created.

They were also left to guess whether Vite's development server — the visible difference between the two build systems — changes anything about a deploy. It does not: `App#build` only starts the development server in `development` (`lib/ember_cli/app.rb`), so production is identical for both blueprints.

Nothing said which NodeJS the build runs on, either. Heroku's NodeJS buildpack reads `engines.node` from the *project root's* `package.json` — the file `rails generate ember:heroku` writes — and builds on the current LTS release when that file names no version, while the Vite-based blueprint requires NodeJS `>= 20.19.0`.

## What changed

- **Heroku** — dropped the Bower buildpack step; stated that a Vite-based application deploys exactly like a classic one; added a NodeJS-version note pointing at the file the buildpack actually reads.
- **Capistrano** — described what the gem installs today (`npm install`, or `yarn install` for a `yarn`-configured application); refreshed the `nvm` `$PATH` example off NodeJS `v4.2.1`; dropped `bower_components` from the `linked_dirs` example.
- Corrected `asset:precompile` to `assets:precompile`, the task `lib/tasks/ember-cli.rake` actually hooks.

## Notes

- Runtime Bower support is deliberately untouched. The gem still supports classic EmberCLI `>= 1.13.13`, so `Shell#install` and the generated `package.json`'s `bower` dependency stay exactly as they are.
- No new Bower prose is added — the Bower-specific steps are simply removed from instructions that presented them as unconditional.
- The NodeJS note asks the reader to check the generated `package.json`. `heroku-generator-node-engines` makes the generator write `engines.node` itself; if that lands, this paragraph stays true and simply becomes a description of what the generator already did.

## Verification

No code changed, so nothing to run. Reviewed the rendered sections for correct anchors (`#vite-based-applications`) and link definitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014rAfkAVGVifbaEoTVeT66u
