### PR TITLE
Drop the Heroku generator's dead code and refresh its USAGE

### DIFF
--- a/lib/generators/ember/heroku/USAGE
+++ b/lib/generators/ember/heroku/USAGE
@@ -1,11 +1,16 @@
 Description:
     Configures a project for deploying to Heroku.
 
-    Once the generator is complete, execute the following:
+    Once the generator is complete, add the buildpacks the deploy needs:
 
         $ heroku buildpacks:clear
         $ heroku buildpacks:add --index 1 heroku/nodejs
         $ heroku buildpacks:add --index 2 heroku/ruby
+
+    `SKIP_EMBER` skips the build wherever it is set. Unset it on the Heroku
+    application, so that `assets:precompile` compiles the EmberCLI
+    applications at deploy time:
+
         $ heroku config:unset SKIP_EMBER
 
 Example:
@@ -16,3 +21,9 @@ Example:
 
     This will create:
         package.json
+
+    An application configured with `yarn` also creates:
+        yarn.lock
+
+    Run the generator again whenever you add an EmberCLI application: the
+    generated `cacheDirectories` names each application's `node_modules`.

--- a/lib/generators/ember/heroku/heroku_generator.rb
+++ b/lib/generators/ember/heroku/heroku_generator.rb
@@ -38,12 +38,6 @@ module EmberCli
       [Rails.root.join("node_modules")]
     end
 
-    def app_paths
-      EmberCli.apps.values.map do |app|
-        app.root_path.relative_path_from(Rails.root)
-      end
-    end
-
     def apps
       EmberCli.apps.values
     end

--- a/spec/generators/ember/init/init_generator_spec.rb
+++ b/spec/generators/ember/init/init_generator_spec.rb
@@ -1,0 +1,23 @@
+require "generator_spec"
+require "generators/ember/init/init_generator"
+
+describe EmberCli::InitGenerator, type: :generator do
+  destination Rails.root.join("tmp", "init_generator_test_output")
+
+  it "generates an initializer that configures an application" do
+    prepare_destination
+
+    run_generator
+
+    expect(destination_root).to have_structure {
+      directory "config" do
+        directory "initializers" do
+          file "ember.rb" do
+            contains "EmberCli.configure"
+            contains "c.app :frontend"
+          end
+        end
+      end
+    }
+  end
+end


### PR DESCRIPTION
Housekeeping across both generators: dead code, a stale `USAGE`, and a missing spec.

## Why

**Dead code.** `HerokuGenerator#app_paths` had no callers — neither the generator nor `package.json.erb` referenced it — so it described a shape of the configuration that nothing depended on.

**`USAGE` drift.** It omitted the `yarn.lock` that `identify_as_yarn_project` writes for a Yarn project, and named `SKIP_EMBER` without saying what unsetting it accomplishes, leaving a reader to guess why the command is in the list at all.

**No spec.** `ember:init` had no coverage at all, so nothing caught a broken initializer template.

## What changed

- Removed `EmberCli::HerokuGenerator#app_paths`.
- Rewrote `lib/generators/ember/heroku/USAGE`: lists `yarn.lock`, explains `SKIP_EMBER`, and notes that the generator should be re-run when an application is added.
- Added `spec/generators/ember/init/init_generator_spec.rb`.

No public API changes, so no CHANGELOG entry.

## Out of scope

- The generator classes stay in the `EmberCli` namespace with their explicit `namespace "ember:heroku"` / `namespace "ember:init"` calls. Rails' own convention would infer them from `lib/generators/ember/...` as `Ember::*`, but that means introducing a new top-level namespace, which is a deliberate call for the maintainer rather than housekeeping.
- `ember:init` still does not add `mount_ember_app` to `config/routes.rb` — the README documents that as a manual step. Changing it alters what the generator does to a project, so it is left for a separate discussion.

## Verification

```
$ bin/rspec spec/generators
6 examples, 0 failures
```

`Rails::Generators.find_by_namespace` still resolves `ember:heroku` → `EmberCli::HerokuGenerator` and `ember:init` → `EmberCli::InitGenerator`.

Full `spec/lib` also passes here except `EmberCli::App#test exits with exit status of 0`, which fails on `main` in this container too — `ember test` reports `Launcher Chrome not found`, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014rAfkAVGVifbaEoTVeT66u
