### PR TITLE
Stop injecting rails_12factor from the Heroku generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+main
+------
+
+* Stop adding `rails_12factor` to the `Gemfile` from `rails generate
+  ember:heroku`. Rails serves the twelve-factor behaviour the gem backported
+  natively since `5.0`, and every Rails version this gem supports is `>= 5.2`.
+  To upgrade, remove `rails_12factor` from your project's `Gemfile`
+
 0.13.2
 ------
 

--- a/lib/generators/ember/heroku/USAGE
+++ b/lib/generators/ember/heroku/USAGE
@@ -11,8 +11,5 @@ Description:
 Example:
     rails generate ember:heroku
 
-    This will install the following gems:
-        rails_12factor
-
     This will create:
         package.json

--- a/lib/generators/ember/heroku/heroku_generator.rb
+++ b/lib/generators/ember/heroku/heroku_generator.rb
@@ -14,10 +14,6 @@ module EmberCli
       end
     end
 
-    def inject_12factor_gem
-      gem "rails_12factor", group: [:staging, :production]
-    end
-
     private
 
     def cache_directories

--- a/spec/generators/ember/heroku/heroku_generator_spec.rb
+++ b/spec/generators/ember/heroku/heroku_generator_spec.rb
@@ -31,6 +31,21 @@ describe EmberCli::HerokuGenerator, type: :generator do
     end
   end
 
+  describe "Gemfile" do
+    it "leaves the Gemfile untouched" do
+      setup_destination
+      configure_application
+
+      run_generator
+
+      expect(gemfile_contents).to eq("")
+    end
+
+    def gemfile_contents
+      destination_root.join("Gemfile").read
+    end
+  end
+
   describe "package.json" do
     it "includes the root directory node_modules" do
       setup_destination
@@ -113,10 +128,10 @@ describe EmberCli::HerokuGenerator, type: :generator do
   def setup_destination
     prepare_destination
 
-    create_empty_gemfile_for_bundler
+    create_empty_gemfile
   end
 
-  def create_empty_gemfile_for_bundler
+  def create_empty_gemfile
     FileUtils.touch(destination_root.join("Gemfile"))
   end
 end


### PR DESCRIPTION
## Why

`rails generate ember:heroku` added `rails_12factor` to the project's `Gemfile` for the `staging` and `production` groups.

The gem exists to backport twelve-factor behaviour — logging to stdout and serving static assets in production — onto Rails 4, which Rails has done natively since `5.0`. Its own README says a new Rails 5 application does not need it, and [its repository was archived in February 2022](https://github.com/heroku/rails_12factor).

Every Rails version this gem supports is `>= 5.2` (`README.md`, "Ruby and Rails support"; the CI matrix runs `7.2`, `8.0`, `8.1` and `main`), so the injection could only ever add an unmaintained dependency to a project that has no use for it.

## What changed

- Removed `HerokuGenerator#inject_12factor_gem`.
- Removed the "This will install the following gems: rails_12factor" line from the generator's `USAGE`.
- Added a spec asserting the generator leaves the `Gemfile` untouched. Renamed the `create_empty_gemfile_for_bundler` helper to `create_empty_gemfile` — with no `gem` action left, the file is now the fixture the assertion reads rather than a prerequisite for Thor.
- CHANGELOG entry with the upgrade note (remove `rails_12factor` from your `Gemfile`).

## Verification

```
$ bin/rspec spec/generators
6 examples, 0 failures
```

The new spec was confirmed meaningful: with `inject_12factor_gem` restored it fails with `+gem "rails_12factor", group: [:staging, :production]` in the diff.

Full `spec/lib` also passes here except `EmberCli::App#test exits with exit status of 0`, which fails on `main` in this container too — `ember test` reports `Launcher Chrome not found`, unrelated to this change.

## Note on merge order

This branch and [#671](https://github.com/tricknotes/ember-cli-rails/pull/671) both edit `lib/generators/ember/heroku/USAGE`; whichever merges second needs a small conflict resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014rAfkAVGVifbaEoTVeT66u


---
_Generated by [Claude Code](https://claude.ai/code/session_014rAfkAVGVifbaEoTVeT66u)_