### PR TITLE
Detect Yarn the same way the installer does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ main
   ember:heroku`. Rails serves the twelve-factor behaviour the gem backported
   natively since `5.0`, and every Rails version this gem supports is `>= 5.2`.
   To upgrade, remove `rails_12factor` from your project's `Gemfile`
+* Replace `EmberCli::App#yarn_enabled?` with `EmberCli::App#yarn?`
 
 0.13.2
 ------

--- a/lib/ember_cli/app.rb
+++ b/lib/ember_cli/app.rb
@@ -91,8 +91,8 @@ module EmberCli
       deploy.mountable?
     end
 
-    def yarn_enabled?
-      options.fetch(:yarn, false)
+    def yarn?
+      paths.yarn?
     end
 
     def bower?

--- a/lib/ember_cli/path_set.rb
+++ b/lib/ember_cli/path_set.rb
@@ -134,6 +134,10 @@ module EmberCli
       @node_modules ||= root.join("node_modules")
     end
 
+    def yarn?
+      app_options[:yarn].present? || app_options[:yarn_path].present?
+    end
+
     def tee
       @tee ||= path_for_executable("tee")
     end
@@ -167,10 +171,6 @@ module EmberCli
       else
         "npm"
       end
-    end
-
-    def yarn?
-      app_options[:yarn] || app_options[:yarn_path]
     end
 
     def app_name

--- a/lib/generators/ember/heroku/heroku_generator.rb
+++ b/lib/generators/ember/heroku/heroku_generator.rb
@@ -9,7 +9,7 @@ module EmberCli
     end
 
     def identify_as_yarn_project
-      if EmberCli.any?(&:yarn_enabled?)
+      if EmberCli.any?(&:yarn?)
         template "yarn.lock.erb", "yarn.lock"
       end
     end

--- a/spec/lib/ember_cli/app_spec.rb
+++ b/spec/lib/ember_cli/app_spec.rb
@@ -33,14 +33,12 @@ describe EmberCli::App do
     end
   end
 
-  describe "yarn_enabled?" do
+  describe "#yarn?" do
     context "when configured with yarn: true" do
       it "returns true" do
         app = EmberCli::App.new("with-yarn", yarn: true)
 
-        yarn_enabled = app.yarn_enabled?
-
-        expect(yarn_enabled).to be true
+        expect(app.yarn?).to be true
       end
     end
 
@@ -48,9 +46,23 @@ describe EmberCli::App do
       it "returns false" do
         app = EmberCli::App.new("without-yarn", yarn: false)
 
-        yarn_enabled = app.yarn_enabled?
+        expect(app.yarn?).to be false
+      end
+    end
 
-        expect(yarn_enabled).to be false
+    context "when configured with yarn_path alone" do
+      it "returns true, matching the executable the installer runs" do
+        app = EmberCli::App.new("with-yarn-path", yarn_path: "/usr/bin/yarn")
+
+        expect(app.yarn?).to be true
+      end
+    end
+
+    context "when configured with neither" do
+      it "returns false" do
+        app = EmberCli::App.new("without-yarn")
+
+        expect(app.yarn?).to be false
       end
     end
   end

--- a/spec/lib/ember_cli/path_set_spec.rb
+++ b/spec/lib/ember_cli/path_set_spec.rb
@@ -212,6 +212,28 @@ describe EmberCli::PathSet do
     end
   end
 
+  describe "#yarn?" do
+    it "is true when yarn is requested" do
+      app = build_app(options: { yarn: true })
+      path_set = build_path_set(app: app)
+
+      expect(path_set).to be_yarn
+    end
+
+    it "is true when only the yarn executable is named" do
+      app = build_app(options: { yarn_path: "/usr/bin/yarn" })
+      path_set = build_path_set(app: app)
+
+      expect(path_set).to be_yarn
+    end
+
+    it "is false when yarn is neither requested nor named" do
+      path_set = build_path_set
+
+      expect(path_set).not_to be_yarn
+    end
+  end
+
   describe "#yarn" do
     it "can be overridden" do
       fake_yarn = create_executable(ember_cli_root.join("yarn"))


### PR DESCRIPTION
## Why

Two implementations answered "does Yarn install this application's dependencies?" and they disagreed.

- `EmberCli::App#yarn_enabled?` read the `yarn` option alone.
- `EmberCli::PathSet#yarn?` — which `Shell#install` reaches through `PathSet#yarn` — also treated `yarn_path` as a request for Yarn. `PathSet#path_for_executable` resolves `yarn_path` without consulting `$PATH`, and `spec/lib/ember_cli/path_set_spec.rb` covers exactly that case.

The Heroku generator asked the first one. An application configured with `yarn_path` alone therefore installed with Yarn everywhere the gem runs the installer, but got no root `yarn.lock` from `rails generate ember:heroku` — so Heroku's NodeJS buildpack, which picks the package manager by the lockfile it finds, fell back to npm for the same project.

## What changed

- `EmberCli::PathSet#yarn?` is now public and returns a boolean instead of the option value.
- `EmberCli::App#yarn_enabled?` is replaced by `EmberCli::App#yarn?`, delegating to `PathSet#yarn?`.
- `HerokuGenerator#identify_as_yarn_project` asks `EmberCli.any?(&:yarn?)`.

The installer stays the single source of truth; the generator becomes one of its readers.

## Compatibility

`EmberCli::App#yarn_enabled?` is removed rather than aliased — the rename is noted in the CHANGELOG. Its only caller in this repository was the Heroku generator.

Behaviour changes for one configuration: `c.app :frontend, yarn_path: "/path/to/yarn"` (without `yarn: true`) now gets a `yarn.lock` from the generator. That is the configuration the bug describes.

## Verification

```
$ bin/rspec spec/lib spec/generators
141 examples, 1 failure
```

The one failure is `EmberCli::App#test exits with exit status of 0`, which fails on `main` in this container too — `ember test` reports `Launcher Chrome not found`, unrelated to this change.

New coverage: `PathSet#yarn?` for `yarn: true`, `yarn_path` alone, and neither; `App#yarn?` for the same three plus `yarn: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014rAfkAVGVifbaEoTVeT66u


---
_Generated by [Claude Code](https://claude.ai/code/session_014rAfkAVGVifbaEoTVeT66u)_