### PR TITLE
Release 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-main
+0.14.0
 ------
 
 * Add the `package_manager` option to install an application's NodeJS

--- a/lib/ember_cli/version.rb
+++ b/lib/ember_cli/version.rb
@@ -1,3 +1,3 @@
 module EmberCli
-  VERSION = "0.13.2".freeze
+  VERSION = "0.14.0".freeze
 end


### PR DESCRIPTION
## Summary

Release 0.14.0, carrying the changes merged since 0.13.2:

* Add the `package_manager` option to install an application's NodeJS dependencies with pnpm (`package_manager: :pnpm`), yarn, or npm. `pnpm_path` implies pnpm the way `yarn_path` implies yarn. The package manager is read through the new `EmberCli::App#package_manager` and `EmberCli::App#pnpm?` (#676)
* Deprecate `yarn: true` in favour of `package_manager: :yarn`. The shorthand still selects yarn, with a deprecation warning, and will be removed in `1.0` (#676)
* Identify a project with a pnpm application to Heroku's NodeJS buildpack from `rails generate ember:heroku`, with a root-level `pnpm-lock.yaml`, and pin the package manager version in the generated `package.json` from the `packageManager` the Ember applications declare, read through the new `EmberCli::App#package_manager_spec` (#676)
* Stop adding `rails_12factor` to the `Gemfile` from `rails generate ember:heroku`. Rails serves the twelve-factor behaviour the gem backported natively since `5.0`, and every Rails version this gem supports is `>= 5.2`. To upgrade, remove `rails_12factor` from your project's `Gemfile` (#672)
* Replace `EmberCli::App#yarn_enabled?` with `EmberCli::App#yarn?` (#673)
* Pin the NodeJS version in the `package.json` that `rails generate ember:heroku` writes, from the `engines.node` the Ember applications declare, read through the new `EmberCli::App#node_engine`. Applications that declare different versions are left unpinned (#674)

Bumps `EmberCli::VERSION` from `0.13.2` to `0.14.0` and retitles the unreleased CHANGELOG section accordingly. A minor bump rather than a patch: the release adds an option, deprecates one, renames `App#yarn_enabled?`, and changes what the Heroku generator writes.

## After merging

Per `RELEASING.md`: tag `v0.14.0` on the merge, push the tag, then `gem build ember-cli-rails.gemspec && gem push ember-cli-rails-0.14.0.gem`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CqY7HBgnyPQb3T3t7zgyyb)_