### PR TITLE
Detect every name Vite resolves its config from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 main
 ------
 
+* Recognise an application as Vite-based from any of the six names Vite
+  resolves its configuration from, rather than only `vite.config.js`,
+  `vite.config.mjs` and `vite.config.ts`. An application configured in
+  `vite.config.mts`, `vite.config.cts` or `vite.config.cjs` was taken for a
+  classic one and served with `ember build --watch`, which a Vite-based
+  project rejects
 * Report the whole `ember build` failure in the `EmberCli::BuildError`
   message, instead of only its first line. The line naming the file that
   failed to build is rarely the first one the build tool writes, so a parse

--- a/lib/ember_cli/path_set.rb
+++ b/lib/ember_cli/path_set.rb
@@ -4,6 +4,17 @@ module EmberCli
   class PathSet
     PACKAGE_MANAGERS = %i[npm yarn pnpm].freeze
 
+    # Every name Vite resolves its configuration file from. An application
+    # that keeps its configuration under any of them is Vite-based.
+    VITE_CONFIG_FILES = %w[
+      vite.config.js
+      vite.config.mjs
+      vite.config.cjs
+      vite.config.ts
+      vite.config.mts
+      vite.config.cts
+    ].freeze
+
     # npm ships with NodeJS, so it has no installation instructions of its own
     # to point at when its executable is missing.
     INSTALL_INSTRUCTIONS = {
@@ -55,8 +66,7 @@ module EmberCli
     # Apps generated with the Vite-based blueprint (`ember-cli >= 6.8`)
     # ship a Vite config file at their root.
     def vite?
-      %w[vite.config.mjs vite.config.js vite.config.ts].
-        any? { |config| root.join(config).exist? }
+      VITE_CONFIG_FILES.any? { |config| root.join(config).exist? }
     end
 
     def ember

--- a/spec/lib/ember_cli/path_set_spec.rb
+++ b/spec/lib/ember_cli/path_set_spec.rb
@@ -162,20 +162,14 @@ describe EmberCli::PathSet do
       expect(path_set).not_to be_vite
     end
 
-    it "is true when the app has a vite.config.mjs" do
-      app = build_app
-      create_file(app_root_for(app).join("vite.config.mjs"))
-      path_set = build_path_set(app: app)
+    EmberCli::PathSet::VITE_CONFIG_FILES.each do |config_file|
+      it "is true when the app has a #{config_file}" do
+        app = build_app
+        create_file(app_root_for(app).join(config_file))
+        path_set = build_path_set(app: app)
 
-      expect(path_set).to be_vite
-    end
-
-    it "is true when the app has a vite.config.js" do
-      app = build_app
-      create_file(app_root_for(app).join("vite.config.js"))
-      path_set = build_path_set(app: app)
-
-      expect(path_set).to be_vite
+        expect(path_set).to be_vite
+      end
     end
   end
 


### PR DESCRIPTION
`PathSet#vite?` decides whether an application came from the Vite-based blueprint by looking for a configuration file at its root, and it looked for three names:

```ruby
%w[vite.config.mjs vite.config.js vite.config.ts]
```

Vite resolves its configuration from six. Taken from the resolver in `vite@8.2.2`:

```
vite.config.cjs  vite.config.cts  vite.config.js
vite.config.mjs  vite.config.mts  vite.config.ts
```

So an application configured in `vite.config.mts`, `vite.config.cts` or `vite.config.cjs` was taken for a classic one.

## What that costs

In `development` a classic application is served by `ember build --watch`, which a Vite-based project refuses. Renaming the config of an `ember-cli` 7.2.0 application to `vite.config.mts` and asking the gem about it, before this change:

```
config: ["vite.config.mts"]
paths.vite? => false
dev_server? => false
```

and the first request then fails with:

```
:frontend has failed to build: The `--watch` option to `ember build` is not
supported in Vite-based projects. Please use `vite dev` instead.
```

After this change, the same application:

```
config: ["vite.config.mts"]
paths.vite? => true
dev_server? => true
```

## The change

The six names live in `PathSet::VITE_CONFIG_FILES`, and `vite?` checks against it. The specs iterate that constant, so a name added to the list is covered without a new example being written for it.

## Tests

* `bin/rspec spec/lib/ember_cli/path_set_spec.rb` — 55 examples, 0 failures
* `bin/rspec spec/lib` — 2 failures, both (`app_spec.rb:192`, `app_spec.rb:200`) failing identically on `main`; they need `node_modules` installed to find the `ember` binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)
