### PR TITLE
Pass --watcher only when the build watches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 main
 ------
 
+* Pass `--watcher` to `ember build` only when the build watches. The flag
+  names the backend that watches the file system, so it did nothing for a
+  one-off build
 * Build a Vite-based application with `vite build`, the command its own
   `build` script runs, rather than with `ember build`. `ember build --help`
   calls itself a "Vestigial command in Vite-based projects" and points at

--- a/lib/ember_cli/command.rb
+++ b/lib/ember_cli/command.rb
@@ -86,11 +86,14 @@ module EmberCli
     # Builds the application with `ember build`, which watches for changes
     # when asked. A Vite-based project has no equivalent: `ember build` there
     # refuses `--watch`, and its development server watches instead.
+    #
+    # `--watcher` names the backend that watches, so it rides along only
+    # when the build watches.
     def ember_build(watch: false)
       line = Terrapin::CommandLine.new(paths.ember, [
         "build",
         ("--watch" if watch),
-        ("--watcher :watcher" if process_watcher),
+        ("--watcher :watcher" if watch && process_watcher),
         ("--silent" if silent?),
         "--environment :environment",
         "--output-path :output_path",

--- a/spec/lib/ember_cli/command_spec.rb
+++ b/spec/lib/ember_cli/command_spec.rb
@@ -77,6 +77,15 @@ describe EmberCli::Command do
       end
     end
 
+    context "when not configured to watch" do
+      it "omits the `--watcher` flag" do
+        paths = build_paths
+        command = build_command(paths: paths, options: { watcher: "foo" })
+
+        expect(command.build).not_to match(/--watcher/)
+      end
+    end
+
     context "when configured to watch" do
       it "includes the `--watch` flag" do
         paths = build_paths


### PR DESCRIPTION
`Command#ember_build` puts `--watcher` on the command line whenever a watcher is configured, whether or not the build watches:

```ruby
("--watch" if watch),
("--watcher :watcher" if process_watcher),
```

`--watcher` names the backend `ember build` watches the file system with, so it has no effect on a build that does not watch. `rake ember:compile` and `assets:precompile` of an application configured with `watcher` — through the app option or `EmberCli.configuration.watcher` — carry the flag for nothing.

## The change

Gate the flag on `watch`:

```ruby
("--watcher :watcher" if watch && process_watcher),
```

and say in the classic builder's comment why it only rides along with `--watch`. A watching build is unchanged, and the existing examples for it already pass `watch: true`, so none of them needed editing.

## Tests

* `bin/rspec spec/lib/ember_cli/command_spec.rb` — 15 examples, 0 failures, including a new one asserting `--watcher` is omitted from a non-watching build
* `bin/rspec spec/lib` — 2 failures, both (`app_spec.rb:192`, `app_spec.rb:200`) failing identically on `main`; they need `node_modules` installed to find the `ember` binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)