### PR TITLE
Build a Vite application with vite build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 main
 ------
 
+* Build a Vite-based application with `vite build`, the command its own
+  `build` script runs, rather than with `ember build`. `ember build --help`
+  calls itself a "Vestigial command in Vite-based projects" and points at
+  that script. The output is unchanged; `silent` now quiets such a build
+  with `--logLevel error` rather than `ember build --silent`
 * Recognise an application as Vite-based from any of the six names Vite
   resolves its configuration from, rather than only `vite.config.js`,
   `vite.config.mjs` and `vite.config.ts`. An application configured in

--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ c.app :frontend, path: "~/projects/my-ember-app"
 - `path` - the path where your Ember CLI application is located. The default
   value is the name of your app in the Rails root.
 
-- `silent` - this provides `--silent` option for Ember CLI commands to control verbosity of their output.
+- `silent` - quiets the build. A classic application is built with
+  `ember build --silent`; a Vite-based one with `vite build --logLevel error`,
+  which keeps errors while dropping the progress output.
 
 - `package_manager` - the package manager that installs the application's
   NodeJS dependencies: `:npm` (the default), `:yarn`, or `:pnpm`. Name the

--- a/lib/ember_cli/command.rb
+++ b/lib/ember_cli/command.rb
@@ -14,7 +14,11 @@ module EmberCli
     end
 
     def build(watch: false)
-      ember_build(watch: watch)
+      if paths.vite?
+        vite_build
+      else
+        ember_build(watch: watch)
+      end
     end
 
     # Boots Vite's development server for an application generated with the
@@ -43,6 +47,45 @@ module EmberCli
       options.fetch(:silent) { false }
     end
 
+    def build_environment
+      if EmberCli.env == "production"
+        "production"
+      else
+        "development"
+      end
+    end
+
+    # The Vite-based blueprint (`ember-cli >= 6.8`)
+    #
+    # Builds the application the way its own `build` script does.
+    # `ember build` still drives such a build today, but `ember build --help`
+    # calls it a "Vestigial command in Vite-based projects" and has dropped
+    # every option but `--environment`, `--suppress-sizes` and
+    # `--output-path`.
+    #
+    # `--emptyOutDir` is needed because the output directory is outside the
+    # Ember application, where Vite leaves stale files in place unless asked
+    # to clear them.
+    def vite_build
+      line = Terrapin::CommandLine.new(paths.vite, [
+        "build",
+        "--mode :mode",
+        "--outDir :output_path",
+        "--emptyOutDir",
+        ("--logLevel error" if silent?),
+      ].compact.join(" "))
+
+      line.command(
+        mode: build_environment,
+        output_path: paths.dist,
+      )
+    end
+
+    # The classic blueprint
+    #
+    # Builds the application with `ember build`, which watches for changes
+    # when asked. A Vite-based project has no equivalent: `ember build` there
+    # refuses `--watch`, and its development server watches instead.
     def ember_build(watch: false)
       line = Terrapin::CommandLine.new(paths.ember, [
         "build",
@@ -58,14 +101,6 @@ module EmberCli
         output_path: paths.dist,
         watcher: process_watcher,
       )
-    end
-
-    def build_environment
-      if EmberCli.env == "production"
-        "production"
-      else
-        "development"
-      end
     end
   end
 end

--- a/spec/lib/ember_cli/command_spec.rb
+++ b/spec/lib/ember_cli/command_spec.rb
@@ -106,8 +106,38 @@ describe EmberCli::Command do
     end
   end
 
+  describe "#build for a Vite-based application" do
+    it "builds a `vite build` command writing to the output path" do
+      paths = build_paths(vite?: true, vite: "path/to/vite", dist: "path/to/dist")
+      command = build_command(paths: paths)
+
+      expect(command.build).to match(%r{path/to/vite build})
+      expect(command.build).to match(/--mode 'development'/)
+      expect(command.build).to match(%r{--outDir 'path/to/dist'})
+      expect(command.build).to match(/--emptyOutDir/)
+    end
+
+    it "does not pass the flags `ember build` takes" do
+      paths = build_paths(vite?: true, vite: "path/to/vite")
+      command = build_command(paths: paths, options: { watcher: "events" })
+
+      expect(command.build(watch: true)).not_to match(/--watch/)
+      expect(command.build(watch: true)).not_to match(/--environment/)
+    end
+
+    it "quiets the build when configured to be silent" do
+      paths = build_paths(vite?: true, vite: "path/to/vite")
+
+      expect(build_command(paths: paths).build).not_to match(/--logLevel/)
+
+      command = build_command(paths: paths, options: { silent: true })
+
+      expect(command.build).to match(/--logLevel error/)
+    end
+  end
+
   def build_paths(**options)
-    double(options).as_null_object
+    double({ vite?: false }.merge(options)).as_null_object
   end
 
   def build_command(**options)


### PR DESCRIPTION
`Command#build` drove every build through `ember build`. In a Vite-based project that command is on its way out. Its own help text says so:

> Vestigial command in Vite-based projects. Use the `build` script from package.json instead.

It now declares only `--environment`, `--suppress-sizes` and `--output-path`, and refuses `--watch` and `--watcher` rather than forwarding them ([`lib/commands/build.js`](https://github.com/ember-cli/ember-cli/blob/master/lib/commands/build.js)). The blueprint's own script is `"build": "vite build"` ([`ember-app-blueprint`](https://github.com/ember-cli/ember-app-blueprint/blob/main/files/package.json)).

So build a Vite application with `vite build`. `Command#build` picks the command from the blueprint, and the two builders sit side by side so what each one needs stays visible.

## The flags

| Was | Is | Why |
| --- | --- | --- |
| `--environment` | `--mode` | Same value, from the same `build_environment` |
| `--output-path` | `--outDir` | The directory Rails serves the application from |
| — | `--emptyOutDir` | Required to keep the behaviour we have: the output directory lies outside the Ember application, and Vite leaves stale files there unless asked |
| `--silent` | `--logLevel error` | Quiets the progress output while leaving errors visible |

`--emptyOutDir` is not an improvement, it is parity. Dropping a `STALE.txt` into the output directory and rebuilding:

| Command | `STALE.txt` |
| --- | --- |
| `ember build --output-path` | removed |
| `vite build --outDir --emptyOutDir` | removed |
| `vite build --outDir` | **left behind** |

## Why not run the `build` script through a package manager

The gem has to pass `--outDir`, and forwarding flags to a package.json script is not portable. Measured against the same application, with the command each package manager actually ran:

| Command | Ran | Result |
| --- | --- | --- |
| `npm run build -- <flags>` | `vite build --outDir … --mode … --emptyOutDir` | builds where asked |
| `npm run build <flags>` | `vite build /tmp/out development` | exits 1 — npm eats the flags and passes the values positionally |
| `pnpm build <flags>` | `vite build --outDir … --mode … --emptyOutDir` | builds where asked |
| `pnpm run build -- <flags>` | `vite build -- --outDir … --mode …` | **exits 0 and writes to `dist`** — the separator reaches the script |

npm needs `--`, pnpm must not have it, and the pnpm failure is silent. Calling `vite` directly avoids the whole question, and keeps the `DependencyError` that `PathSet#vite` raises when the executable is missing.

## Verification

Against the sandbox application (`ember-cli` 7.2.0, `vite` 8.2.2):

* `rake ember:compile` exits 0, running
  `…/node_modules/.bin/vite build --mode 'development' --outDir '…/tmp/ember-cli/apps/frontend' --emptyOutDir`
* The output is **byte-for-byte the same set of files** as `ember build --environment development --output-path` produced — `diff` of the two file listings, with content hashes normalised, is empty
* The Embroider compat prebuild still runs (`Built project successfully. Stored in ".../tmp/compat-prebuild"`)
* A production build (`--mode production`) writes `index.html` plus every asset it references

## Tests

* `bin/rspec spec/lib/ember_cli/command_spec.rb` — 14 examples, 0 failures, including three for the Vite build
* `bin/rspec spec/lib` — 2 failures, both (`app_spec.rb:192`, `app_spec.rb:200`) failing identically on `main`; they need `node_modules` installed to find the `ember` binary

`ember test` is untouched: it is not vestigial in a Vite project and still works, so `rake ember:test` keeps running it. The blueprint has begun moving that to `testem ci` directly, which is worth its own look later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
