### PR TITLE
Release 0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,29 @@
 main
 ------
 
-* Pass `--watcher` to `ember build` only when the build watches. The flag
-  names the backend that watches the file system, so it did nothing for a
-  one-off build
 * Build a Vite-based application with `vite build`, the command its own
   `build` script runs, rather than with `ember build`. `ember build --help`
   calls itself a "Vestigial command in Vite-based projects" and points at
-  that script. The output is unchanged; `silent` now quiets such a build
-  with `--logLevel error` rather than `ember build --silent`
+  that script. What the build writes is unchanged, and so is the classic
+  blueprint, which keeps building with `ember build`. The `silent` option
+  now quiets a Vite build with `--logLevel error`, which drops the progress
+  output and keeps the errors
 * Recognise an application as Vite-based from any of the six names Vite
   resolves its configuration from, rather than only `vite.config.js`,
   `vite.config.mjs` and `vite.config.ts`. An application configured in
   `vite.config.mts`, `vite.config.cts` or `vite.config.cjs` was taken for a
   classic one and served with `ember build --watch`, which a Vite-based
   project rejects
-* Report the whole `ember build` failure in the `EmberCli::BuildError`
-  message, instead of only its first line. The line naming the file that
-  failed to build is rarely the first one the build tool writes, so a parse
-  error was reported with its message and line number but no way to tell
-  which file it came from
+* Report the whole build failure of a classic application in the
+  `EmberCli::BuildError` message, instead of only its first line. Such an
+  application builds in the background, and `BuildMonitor` turns what
+  `ember build --watch` writes into the exception; the line naming the file
+  that failed to build is rarely the first one, so a parse error arrived
+  with its message and line number but no way to tell which file it came
+  from
+* Pass `--watcher` to `ember build` only when the build watches. The flag
+  names the backend that watches the file system, so it did nothing for a
+  one-off build
 
 0.14.0
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-main
+0.14.1
 ------
 
 * Build a Vite-based application with `vite build`, the command its own

--- a/lib/ember_cli/version.rb
+++ b/lib/ember_cli/version.rb
@@ -1,3 +1,3 @@
 module EmberCli
-  VERSION = "0.14.0".freeze
+  VERSION = "0.14.1".freeze
 end


### PR DESCRIPTION
Two commits: the entries are sharpened first, then the section is named and the version bumped.

## What 0.14.1 ships

Everything since `0.14.0` is about the Vite-based blueprint and how failures from either blueprint are reported. No new options, nothing removed.

| # | Change | Blueprint |
| --- | --- | --- |
| #681 | Build with `vite build` rather than `ember build` | Vite |
| #679 | Recognise all six `vite.config.*` names | Vite |
| #678 | Report the whole build failure, not its first line | classic |
| #680 | Pass `--watcher` only when the build watches | classic |

The diff since `0.14.0` is `lib/ember_cli/{command,path_set,build_monitor}.rb`, their specs, and the `silent` entry in the README — every one of them covered by an entry.

## What changed in the entries

The entries were written one PR at a time, and two of them read as though they touched both blueprints:

* the build failure reporting is `BuildMonitor`, which only sees a classic application's `ember build --watch` output
* moving to `vite build` leaves `ember build` in place for classic applications

Both now say so. The order is what someone upgrading would want: what changes how their application is built, then what was broken, then what was only untidy.

## The one behaviour change to notice

`silent: true` on a Vite application now runs `vite build --logLevel error` instead of `ember build --silent`. Progress output is dropped and errors are kept. Everything else — the files a build writes, and the whole of the classic blueprint — is as it was.

## Version

`0.14.1`, as a patch: the four changes are fixes and an internal swap of the build command, with the build output unchanged. The `silent` mapping above is the only user-visible difference, and it affects an option's verbosity rather than its meaning. Say the word if you would rather this went out as `0.15.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)