### PR TITLE
Accept terrapin 1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+main
+------
+
+* Accept terrapin `1.x` alongside `0.6`, which also lifts the `climate_control < 1.0` that pinning `0.6` imposed
+
 0.14.1
 ------
 

--- a/ember-cli-rails.gemspec
+++ b/ember-cli-rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "ember-cli-rails-assets", ">= 0.9.0", "< 1.0"
   spec.add_dependency "railties", ">= 4.2"
   spec.add_dependency "rack", ">= 2.1", "< 4.0"
-  spec.add_dependency "terrapin", "~> 0.6.0"
+  spec.add_dependency "terrapin", ">= 0.6.0", "< 2.0"
   spec.add_dependency "html_page", "~> 0.1.0"
 
   spec.add_development_dependency "generator_spec", "~> 0.9.0"


### PR DESCRIPTION
The gemspec pinned `terrapin ~> 0.6.0` — a version from February 2018. terrapin has been at `1.x` since November 2023.

```ruby
-  spec.add_dependency "terrapin", "~> 0.6.0"
+  spec.add_dependency "terrapin", ">= 0.6.0", "< 2.0"
```

## Why `1.0` is safe here

Its only breaking change was the removal of one class:

> `Terrapin::CommandLine::PosixRunner` was removed. You can replace any usage of this with `Terrapin::CommandLine::ProcessRunner`, which uses Ruby's builtin `Process.spawn`.

Nothing here uses a runner. Every use of terrapin in this gem builds a command line and stops there — `Command` calls `Terrapin::CommandLine#command` and hands the resulting string to `Runner` (Open3) or `Kernel.spawn`:

```
lib/ember_cli/command.rb:13   line.command
lib/ember_cli/command.rb:35   line.command(host: …, port: …)
lib/ember_cli/command.rb:78   line.command(mode: …, output_path: …)
lib/ember_cli/command.rb:102  line.command(environment: …, output_path: …, watcher: …)
```

Against terrapin `1.1.1` those strings come out as they did under `0.6.0`, shell quoting of interpolated values included:

```
/path/to/vite build --mode 'production' --outDir '/tmp/out dir' --emptyOutDir
/path/to/ember test --environment test
```

## The pin reached past this gem

terrapin `0.6.0` requires `climate_control >= 0.0.3, < 1.0`. Since this gem pinned terrapin to `0.6`, **every application depending on ember-cli-rails was held below `climate_control 1.0`**, with no way out short of dropping the gem. terrapin `1.x` requires only `climate_control >= 0`; installing `1.1.1` here pulled `climate_control` from `0.2.0` to `1.2.0`.

## Tests

With terrapin `1.1.1` and `climate_control 1.2.0` resolved locally:

* `bin/rspec spec/lib` — 174 examples, 2 failures, both (`app_spec.rb:192`, `app_spec.rb:200`) failing identically on `main`; they need `node_modules` installed to find the `ember` binary
* `bin/rspec spec/lib/ember_cli/command_spec.rb` — 15 examples, 0 failures

## One thing to note

`Gemfile.lock` is not committed here, so once this lands CI resolves terrapin to the newest allowed version and `0.6` stops being exercised. The constraint still permits it for applications that have it locked. If keeping `0.6` under test matters, a matrix axis pinning it would be the way, and I can add one.