### PR TITLE
Drop the codeclimate-test-reporter development dependency

### DIFF
--- a/ember-cli-rails.gemspec
+++ b/ember-cli-rails.gemspec
@@ -25,5 +25,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-rails", ">= 3.6.0", "< 9.0"
 
   spec.add_development_dependency "capybara-selenium"
-  spec.add_development_dependency "codeclimate-test-reporter", "~> 0.6.0"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,9 +2,6 @@
 # progress as it happens, so a slow or stuck job shows where it stopped.
 $stdout.sync = true
 
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
-
 ENV["RAILS_ENV"] = "test"
 
 require "dummy/application"


### PR DESCRIPTION
`spec/spec_helper.rb` has started a Code Climate test reporter on every run since 2015. It has never reported anything.

## It is a no-op here

`CodeClimate::TestReporter.start` starts SimpleCov only when the reporter decides to run, and that decision needs an environment variable:

```ruby
def self.run?
  environment_variable_set? && run_on_current_branch?
end

def self.environment_variable_set?
  @environment_variable_set = !!ENV["CODECLIMATE_REPO_TOKEN"]
  ...
end
```

Nothing in this repository sets `CODECLIMATE_REPO_TOKEN` — not `.github/workflows/tests.yml`, not `bin/setup`, not the Rakefile. There is no `.codeclimate.yml` and no badge in the README. Running the two lines from `spec_helper.rb` as they stand:

```
run? = false
CODECLIMATE_REPO_TOKEN set? = false
SimpleCov.running = false
```

So SimpleCov never starts, no coverage is measured, and nothing is uploaded. The `/coverage/` entry in `.gitignore` has been guarding a directory that is never written.

## It is deprecated upstream

* [codeclimate/ruby-test-reporter](https://github.com/codeclimate/ruby-test-reporter) was archived on 2025-07-19. Its README: *"These configuration instructions refer to a language-specific test reporter who is now deprecated in favor of our new unified test reporter client."*
* The gem's [last release is 1.0.9, from 2018-10-08](https://rubygems.org/gems/codeclimate-test-reporter). The gemspec pinned `~> 0.6.0`, older still.
* Code Climate Quality has been succeeded by Qlty, and [its migration guide](https://docs.qlty.sh/migration/guide) states the old test reporter is not supported there. Adopting coverage reporting again would mean a new client and a new service, not a version bump.

## Changes

* `spec/spec_helper.rb`: drop the `require` and the `start` call
* `ember-cli-rails.gemspec`: drop the development dependency

No `CHANGELOG.md` entry: this is a development dependency and nothing an application using the gem can observe changes.

`Gemfile.lock` is not committed, so there is nothing to regenerate here. Locally the removal also drops `simplecov`, `simplecov-html` and `simplecov_json_formatter` from the development bundle.

## Tests

`bin/rspec spec/lib` gives the same result before and after: 174 examples, 2 failures. Both failures (`app_spec.rb:192`, `app_spec.rb:200`) are present on `main` and need `node_modules` installed to find the `ember` binary.
