### PR TITLE
Accept generator_spec 0.10.0

### DIFF
--- a/ember-cli-rails.gemspec
+++ b/ember-cli-rails.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "terrapin", ">= 0.6.0", "< 2.0"
   spec.add_dependency "html_page", "~> 0.1.0"
 
-  spec.add_development_dependency "generator_spec", "~> 0.9.0"
+  spec.add_development_dependency "generator_spec", ">= 0.9.0", "< 1.0"
   spec.add_development_dependency "rspec-rails", ">= 3.6.0", "< 9.0"
 
   spec.add_development_dependency "capybara-selenium"


### PR DESCRIPTION
```ruby
-  spec.add_development_dependency "generator_spec", "~> 0.9.0"
+  spec.add_development_dependency "generator_spec", ">= 0.9.0", "< 1.0"
```

`~> 0.9.0` rejects 0.10.0, which [was released on 2024-01-25](https://rubygems.org/gems/generator_spec) — the same day as 0.9.5, the newest version the pin allows.

## The difference is additive

Diffing the two gems' `lib/` directories, `0.10.0` adds a `does_not_contain` matcher to `have_structure` and a failure message for it:

```ruby
+      def does_not_contain(text)
+        @negative_contents << text
+      end
```

Nothing was removed or changed in what `have_structure`, `destination`, `run_generator` or `prepare_destination` already did, and the runtime requirements are the same in both versions: `activesupport >= 3.0.0` and `railties >= 3.0.0`.

## Tests

With `generator_spec 0.10.0` resolved locally:

* `bin/rspec spec/generators` — 15 examples, 0 failures
* `bin/rspec` — same 6 failures as on `main`, all from the dummy Ember application not being built in this environment

## No CHANGELOG entry

This is a development dependency, so nothing an application using the gem can observe changes.
